### PR TITLE
Changed `once` to `on`

### DIFF
--- a/lib/live-reload.js
+++ b/lib/live-reload.js
@@ -76,7 +76,7 @@ dirs.forEach(function (dir) {
 });
 
 wss.on('connection', function ( ws ) {
-  emitter.once('reload', function () {
+  emitter.on('reload', function () {
     ws.send(JSON.stringify({r: Date.now().toString()}), function ( e ) {
       if ( !e ) { return; }
       console.log(e);


### PR DESCRIPTION
This reloader script only sends a reload message once, for the first change in the directory. Further changes in the directory does not fire subsequent reload messages to the browser.

Changing `emitter.once('reload' ...)` to `emitter.on('reload', ...)` makes it reload for all further changes.
